### PR TITLE
Adding `args` and `kwargs` parameters to `scriptify`

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -16,9 +16,6 @@ jobs:
         - "3.8"
         - "3.9"
         - "3.10"
-        poetry-version:
-        - "1.2.0a2"
-        - "1.2.0b2"
     steps:
     - uses: actions/checkout@v2
 
@@ -27,11 +24,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - 
-      name: Set up poetry
-      uses: abatilo/actions-poetry@v2.0.0
-      with:
-        poetry-version: ${{ matrix.poetry-version }}
+
     -
       name: Install tox
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pycqa/isort
-  rev: 5.8.0
+  rev: 5.12.0
   hooks:
   - id: isort
     name: isort (python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ sphinx-material = "^0.0.34"
 pre-commit = "^2.20.0"
 
 [build-system]
-requires = ["poetry>=1.2.0a2"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry>1.2.0a2"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 markers = [

--- a/tox.ini
+++ b/tox.ini
@@ -8,28 +8,20 @@ python =
     3.9: py39
     3.10: py310
 
-[base]
-commands =
-    poetry install -v 
-    poetry run pytest tests {env:marks}
-
 [testenv]
-allowlist_externals = poetry
+deps = 
+    pytest>=6,<7
+    pytest-depends>=1,<2
+commands = pytest tests {env:marks}
 
 [testenv:py38]
-commands =
-    {[base]commands}
 setenv =
     marks = -m "not gtpy38 and not gtpy39"
 
 [testenv:py39]
-commands =
-    {[base]commands}
 setenv =
     marks = -m "not gtpy39"
 
 [testenv:py310]
-commands =
-    {[base]commands}
 setenv =
     marks = ""


### PR DESCRIPTION
Adding functionality to `scriptify` whereby arguments meant for other functions may be parsed into `**kwargs` or `*args`. Take for example a file called `main.py`

```python
from typeo import scriptify


def commonly_reused_function(name: str, num_greetings: int):
    for i in range(num_greetings):
        print(f"Hi {name}!")


@scriptify(kwargs=commonly_reused_function)
def main(greeter: str, year: int, **kwargs):
    print(f"This is a greeting from {greeter} in the year {year}:")
    commonly_reused_function(**kwargs)


if __name__ == "__main__":
    main()
```

This could be called at the command line by

```console
python main.py --greeter Thom --year 2023 --name Jonny --num-greetings 2

This is a greeting from Thom in the year 2023:
Hi Jonny!
Hi Jonny!
```

For arguments specified as `args`, these are exposed as an argument in `kwargs`, so for example if you had `greet.py`:
```python
from typeo import scriptify


def greet(name: str, num_greetings: int):
    for i in range(num_greetings):
        print(f"Hi {name}!")


if __name__ == "__main__":
    greet()
```
and `main.py`
```python
import subprocess
from greet import greet


@scriptify(args=greet)
def main(greeter: str, year: int, **kwargs):
    print(f"This is a greeting from {greeter} in the year {year}:")
    subprocess.call(["python", "greet.py"] + kwargs["args"])


if __name__ == "__main__":
    main()
```
This will pass any extra command line arguments that weren't parse-able by `main` to the `args` kwarg which can be used to call other command line processes under the hood. The benefit is that the parser will check if you have all the correct arguments at parse time (if any arguments of `main` overlapped with those of `greet`, it would ignore them and assume that you do the due diligence of passing them yourself when you make the command line call).